### PR TITLE
OPS-8196 replace waitForTimeout with waitForSelector with Drupal body class

### DIFF
--- a/library/engine_scripts/onReadyAuth.js
+++ b/library/engine_scripts/onReadyAuth.js
@@ -28,5 +28,6 @@ module.exports = async (page, scenario, vp) => {
   }
 
   await page.goto(scenario.url);
-  await page.waitForTimeout(4000);
+  // Wait for Drupal .user-logged-in class on body.
+  await page.waitForSelector('.user-logged-in')
 };


### PR DESCRIPTION
The class `user-logged-in` is added to the body class once the user is logged in. I _think_ this is broad enough for all Drupal roles but still specific to Drupal sites, which may or may not be an impediment in the future. For now VRT is being used mainly on Drupal sites (the authenticated user tests especially) so this is fine.